### PR TITLE
[YouTube] support seconds-only seek urls

### DIFF
--- a/data/youtube.js
+++ b/data/youtube.js
@@ -320,7 +320,7 @@
             seek = location.search.match(/[&?]t=([^&]*)/)[1];
             var h = seek.match(/(\d+)h/);
             var m = seek.match(/(\d+)m/);
-            var s = seek.match(/(\d+)s/);
+            var s = seek.match(/(\d+)s/) || seek.match(/(\d+)/);
             seek = (h ? parseInt(h[1]) : 0) * 3600 +
                 (m ? parseInt(m[1]) : 0) * 60 +
                 (s ? parseInt(s[1]) : 0);


### PR DESCRIPTION
This addon does support for the `t` parameter using the format `t=10m5s`, but it does currently not work with `t=605`.
There happen to be a lot of links using that format.
