### PR TITLE
Fix embedded youtube videos auto playing in background.

### DIFF
--- a/data/video-player.js
+++ b/data/video-player.js
@@ -154,10 +154,8 @@ VP.prototype.clean = function() {
         if (this.player === vds[i])
             continue;
         vds[i].pause();
-        vds[i].src = "";
         vds[i].addEventListener("playing", (e) => {
             e.currentTarget.pause();
-            e.currentTarget.src = "";
         });
     }
     rmChildren(this.container);


### PR DESCRIPTION
Something in the youtube's giant mess of code is responding to setting
src = "".

Fixes #77